### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Welcome to my personal stock portfolio tracker — a data-driven project built with **Python** and **Jupyter Notebook** to monitor and analyze individual stocks in my investment portfolio. 
 
-I have made this repository to track long-term performance of each stocks. Google and Yahoo finance only showed the net income of recent 5 years.
+I have made this repository to track long-term performance of each stock. Google and Yahoo finance only showed the net income of recent 5 years.
 
 This repository gets data from SEC EDGAR (using sec-edgar-api), and tracks net income history over decades. 
 


### PR DESCRIPTION
## Summary
- fix typo "each stock" in README
- ensure file ends with newline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846cbaa9f5483259a9c35542a88970f